### PR TITLE
fix: Use ConfigureAwait(false) for all awaiting calls

### DIFF
--- a/src/EventSourcingDb/Client.cs
+++ b/src/EventSourcingDb/Client.cs
@@ -22,15 +22,15 @@ public class Client
         var pingUrl = new Uri(_baseUrl, "/api/v1/ping");
 
         using var request = new HttpRequestMessage(HttpMethod.Get, pingUrl);
-        using var response = await Client._httpClient.SendAsync(request);
+        using var response = await Client._httpClient.SendAsync(request).ConfigureAwait(false);
 
         if (response.StatusCode != System.Net.HttpStatusCode.OK)
         {
             throw new Exception($"Failed to ping, got HTTP status code '{(int)response.StatusCode}', expected '200'.");
         }
 
-        using var responseStream = await response.Content.ReadAsStreamAsync();
-        using var responseJson = await JsonDocument.ParseAsync(responseStream);
+        using var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        using var responseJson = await JsonDocument.ParseAsync(responseStream).ConfigureAwait(false);
 
         if (!responseJson.RootElement.TryGetProperty("type", out var typeElement) || typeElement.ValueKind != JsonValueKind.String)
         {

--- a/src/EventSourcingDb/Container.cs
+++ b/src/EventSourcingDb/Container.cs
@@ -52,7 +52,7 @@ public class Container
             .WithCleanUp(true);
 
         this._container = builder.Build();
-        await this._container.StartAsync();
+        await this._container.StartAsync().ConfigureAwait(false);
     }
 
     public string GetHost()
@@ -85,8 +85,8 @@ public class Container
     {
         if (this._container is not null)
         {
-            await this._container.StopAsync();
-            await this._container.DisposeAsync();
+            await this._container.StopAsync().ConfigureAwait(false);
+            await this._container.DisposeAsync().ConfigureAwait(false);
             this._container = null;
         }
     }


### PR DESCRIPTION
Adjusted all asynchronous calls in `Container.cs` and `Client.cs` to use `ConfigureAwait(false)` for better performance and to avoid deadlocks in non-UI thread contexts. This ensures more predictable behavior in library and background thread scenarios.