### PR TITLE
feat: Support deserialization for types known at runtime

### DIFF
--- a/src/EventSourcingDb.Tests/WriteEventsTests.cs
+++ b/src/EventSourcingDb.Tests/WriteEventsTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -145,6 +146,26 @@ public class WriteEventsTests : IAsyncLifetime
         );
 
         Assert.Equal(HttpStatusCode.Conflict, error.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeserializesEventDataCorrectly()
+    {
+        var client = _container!.GetClient();
+
+        var eventCandidate = new EventCandidate(
+            Source: "https://www.eventsourcingdb.io",
+            Subject: "/test",
+            Type: "io.eventsourcingdb.test",
+            Data: new EventData(42)
+        );
+
+        var writtenEvents = await client.WriteEventsAsync([eventCandidate]);
+
+        var data = writtenEvents[0].GetData(typeof(EventData));
+
+        Assert.IsType<EventData>(data);
+        Assert.Equal(eventCandidate.Data, data);
     }
 
     private record struct EventData(int Value);

--- a/src/EventSourcingDb/Types/Event.cs
+++ b/src/EventSourcingDb/Types/Event.cs
@@ -38,4 +38,7 @@ public record Event(
 
     public T? GetData<T>() =>
         Data.Deserialize<T>(_defaultSerializerOptions);
+
+    public object? GetData(Type type) =>
+        Data.Deserialize(type, _defaultSerializerOptions);
 }


### PR DESCRIPTION
Hi there,

most of the time, the event types retrieved from EventSourcingDB will not be known at design time. Therefore, support for deserializing by type at runtime is needed. Also, users need control over serialization options at some time... 

I also would like to extend/add tests for deserialization as it also serves as a reference for developers.

Unfortunately I can not run the tests (screenshot attached). @JezhikLaas @goloroden Do I have to do any setup steps?

![image](https://github.com/user-attachments/assets/47705b5d-442a-498b-8038-8a4464eccf77)

Best

Chris