### PR TITLE
feat: Support running tests on Windows

### DIFF
--- a/src/EventSourcingDb.Tests/DockerfileHelper.cs
+++ b/src/EventSourcingDb.Tests/DockerfileHelper.cs
@@ -33,6 +33,6 @@ public static class DockerfileHelper
             throw new InvalidOperationException("Failed to find image version in Dockerfile.");
         }
 
-        return match.Groups[1].Value;
+        return match.Groups[1].Value.Replace("\r", string.Empty);
     }
 }


### PR DESCRIPTION
On Windows, line endings are represented by `\r\n`. The multiline mode regex matching when parsing the image tag captures `\r` at the end of the group. If this special character is left, then the Testcontainer code complains (throws) that the image tag string is not valid.

Tested on Ubuntu that tests still run.
Did not test on MacOS, but line endings should be the same as on Linux (`\n`).