### PR TITLE
feat: Pass error messages in the exception when writing events

### DIFF
--- a/src/EventSourcingDb.Tests/WriteEventsTests.cs
+++ b/src/EventSourcingDb.Tests/WriteEventsTests.cs
@@ -174,9 +174,11 @@ public class WriteEventsTests : IAsyncLifetime
     {
         var client = _container!.GetClient();
 
+        const string invalidSubject = "test"; // Subjects must start with a slash
+
         var eventCandidate = new EventCandidate(
             Source: "https://www.eventsourcingdb.io",
-            Subject: "test", // Invalid subject, should start with a slash
+            Subject: invalidSubject,
             Type: "io.eventsourcingdb.test",
             Data: new EventData(42)
         );

--- a/src/EventSourcingDb/Client.cs
+++ b/src/EventSourcingDb/Client.cs
@@ -154,7 +154,7 @@ public class Client
             {
                 var errorResponse = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
                 throw new HttpRequestException(
-                    message: $"Unexpected status code - {errorResponse}", inner: null, statusCode: response.StatusCode
+                    message: $"Unexpected status code ('{errorResponse}').", inner: null, statusCode: response.StatusCode
                 );
             }
 


### PR DESCRIPTION
Working with EventSourcingDB, I ran into errors many times. Then I had to debug or check the logs of the Docker container.

DX would improve if the error messges are passed in the exceptions directly. There may be few other places where this applies, but writing events is a good start ☺️