### PR TITLE
feat: Add support for the `isEventQlTrue` precondition

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ var writtenEvents = await client.WriteEventsAsync(
 
 *Note that according to the CloudEvents standard, event IDs must be of type string.*
 
+### Using the `isEventQlTrue` precondition
+
+If you want to write events depending on an EventQL query, use the `IsEventQlTruePrecondition`:
+
+```csharp
+var writtenEvents = await client.WriteEventsAsync(
+    new[] { @event },
+    new[] { Precondition.IsEventQlTruePrecondition("FROM e IN events WHERE e.type == 'io.eventsourcingdb.library.book-borrowed' PROJECT INTO COUNT() < 10") }
+);
+```
+
+*Note that the query must return a single row with a single value, which is interpreted as a boolean.*
+
 ## Reading Events
 
 To read all events of a subject, call the `ReadEventsAsync` method and pass the subject and an options object. Set `Recursive` to `false` to ensure that only events of the given subject are returned, not events of nested subjects.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,1 +1,1 @@
-FROM thenativeweb/eventsourcingdb:1.0.3
+FROM thenativeweb/eventsourcingdb:preview

--- a/src/EventSourcingDb/Types/IsEventQlTruePrecondition.cs
+++ b/src/EventSourcingDb/Types/IsEventQlTruePrecondition.cs
@@ -1,0 +1,3 @@
+namespace EventSourcingDb.Types;
+
+public record IsEventQlTruePrecondition(string Query);

--- a/src/EventSourcingDb/Types/Precondition.cs
+++ b/src/EventSourcingDb/Types/Precondition.cs
@@ -13,4 +13,7 @@ public record Precondition
 
     public static Precondition IsSubjectOnEventIdPrecondition(string subject, string eventId) =>
         new Precondition { Type = "isSubjectOnEventId", Payload = new IsSubjectOnEventIdPrecondition(subject, eventId) };
+
+    public static Precondition IsEventQlTruePrecondition(string query) =>
+        new Precondition { Type = "isEventQlTrue", Payload = new IsEventQlTruePrecondition(query) };
 }


### PR DESCRIPTION
Adds support for the `isEventQlTrue` precondition to write depending on an EventQL query. Only available using the `preview` Docker image at this point in time.