### PR TITLE
chore: Move common test initialization to base class

### DIFF
--- a/src/EventSourcingDb.Tests/CustomSerializationOptionsTests.cs
+++ b/src/EventSourcingDb.Tests/CustomSerializationOptionsTests.cs
@@ -6,25 +6,8 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class CustomSerializationOptionsTests : IAsyncLifetime
+public class CustomSerializationOptionsTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task UsesCustomSerializationOptionsToControlSerialization()
     {
@@ -33,7 +16,7 @@ public class CustomSerializationOptionsTests : IAsyncLifetime
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Converters = { new JsonStringEnumConverter() }
         };
-        var client = _container!.GetClient(serializerOptions);
+        var client = Container!.GetClient(serializerOptions);
 
         var eventCandidate = new EventCandidate(
             Source: "https://www.eventsourcingdb.io",

--- a/src/EventSourcingDb.Tests/DependencyInjectionTests.cs
+++ b/src/EventSourcingDb.Tests/DependencyInjectionTests.cs
@@ -8,30 +8,13 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public sealed class DependencyInjectionTests : IAsyncLifetime
+public sealed class DependencyInjectionTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task ClientIsAvailableUsingDependencyInjection()
     {
-        var url = _container!.GetBaseUrl();
-        var apiToken = _container!.GetApiToken();
+        var url = Container!.GetBaseUrl();
+        var apiToken = Container!.GetApiToken();
 
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(

--- a/src/EventSourcingDb.Tests/EventSourcingDbTests.cs
+++ b/src/EventSourcingDb.Tests/EventSourcingDbTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class EventSourcingDbTests: IAsyncLifetime
+public class EventSourcingDbTests : IAsyncLifetime
 {
     protected Container? Container { get; private set; }
 

--- a/src/EventSourcingDb.Tests/EventSourcingDbTests.cs
+++ b/src/EventSourcingDb.Tests/EventSourcingDbTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace EventSourcingDb.Tests;
+
+public class EventSourcingDbTests: IAsyncLifetime
+{
+    protected Container? Container { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
+        Container = new Container().WithImageTag(imageVersion);
+        await Container.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (Container is not null)
+        {
+            await Container.StopAsync();
+        }
+    }
+}

--- a/src/EventSourcingDb.Tests/ObserveEventsTests.cs
+++ b/src/EventSourcingDb.Tests/ObserveEventsTests.cs
@@ -7,29 +7,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class ObserveEventsTests : IAsyncLifetime
+public class ObserveEventsTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task ObserveNoEventsIfTheDatabaseIsEmpty()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
         var didReadEvents = false;
 
         var options = new ObserveEventsOptions(Recursive: true);
@@ -53,7 +36,7 @@ public class ObserveEventsTests : IAsyncLifetime
     [Fact]
     public async Task ObserveAllEventsFromTheGivenSubject()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -95,7 +78,7 @@ public class ObserveEventsTests : IAsyncLifetime
     [Fact]
     public async Task ObservesWithLowerBound()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -144,7 +127,7 @@ public class ObserveEventsTests : IAsyncLifetime
     [Fact]
     public async Task ObservesFromLatestEvent()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);

--- a/src/EventSourcingDb.Tests/PingTests.cs
+++ b/src/EventSourcingDb.Tests/PingTests.cs
@@ -6,29 +6,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public sealed class PingTests : IAsyncLifetime
+public sealed class PingTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task DoesNotThrowIfServerIsReachable()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         // Should not throw.
         await client.PingAsync();
@@ -37,8 +20,8 @@ public sealed class PingTests : IAsyncLifetime
     [Fact]
     public async Task ThrowsIfServerIsNotReachable()
     {
-        var port = _container!.GetMappedPort();
-        var apiToken = _container.GetApiToken();
+        var port = Container!.GetMappedPort();
+        var apiToken = Container.GetApiToken();
 
         var invalidUri = new Uri($"http://non-existent-host:{port}/");
         var client = new Client(invalidUri, apiToken);

--- a/src/EventSourcingDb.Tests/ReadEventTypeTest.cs
+++ b/src/EventSourcingDb.Tests/ReadEventTypeTest.cs
@@ -7,29 +7,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class ReadEventTypeTest : IAsyncLifetime
+public class ReadEventTypeTest : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task FailsIfTheEventTypeDoesNotExist()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         try
         {
@@ -49,7 +32,7 @@ public class ReadEventTypeTest : IAsyncLifetime
     [Fact]
     public async Task FailsIfTheEventTypeIsMalformed()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         try
         {
@@ -69,7 +52,7 @@ public class ReadEventTypeTest : IAsyncLifetime
     [Fact]
     public async Task ReadsAnExistingEventType()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(42);
 

--- a/src/EventSourcingDb.Tests/ReadEventTypesTest.cs
+++ b/src/EventSourcingDb.Tests/ReadEventTypesTest.cs
@@ -11,29 +11,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class ReadEventTypesTest : IAsyncLifetime
+public class ReadEventTypesTest : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task ReadsNoEventTypesIfTheDatabaseIsEmpty()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
         var eventTypesRead = await client.ReadEventTypesAsync().ToListAsync();
 
         Assert.Empty(eventTypesRead);
@@ -42,7 +25,7 @@ public class ReadEventTypesTest : IAsyncLifetime
     [Fact]
     public async Task ReadsAllEventTypes()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -80,10 +63,10 @@ public class ReadEventTypesTest : IAsyncLifetime
     [Fact]
     public async Task SupportsReadingEventSchemas()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         // TODO: simplify this once schema registration is supported by the client.
-        var registerEventSchemaUrl = new Uri(_container.GetBaseUrl(), "/api/v1/register-event-schema");
+        var registerEventSchemaUrl = new Uri(Container.GetBaseUrl(), "/api/v1/register-event-schema");
         var eventSchema = new
         {
             Type = "object",
@@ -92,7 +75,7 @@ public class ReadEventTypesTest : IAsyncLifetime
         };
 
         using var request = new HttpRequestMessage(HttpMethod.Post, registerEventSchemaUrl);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _container.GetApiToken());
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Container.GetApiToken());
         request.Content = new StringContent(
             JsonSerializer.Serialize(new
             {

--- a/src/EventSourcingDb.Tests/ReadEventsTests.cs
+++ b/src/EventSourcingDb.Tests/ReadEventsTests.cs
@@ -5,29 +5,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class ReadEventsTests : IAsyncLifetime
+public class ReadEventsTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task ReadsNoEventsIfTheDatabaseIsEmpty()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
         var eventsRead = await client.ReadEventsAsync("/", new ReadEventsOptions(Recursive: true)).ToListAsync();
 
         Assert.Empty(eventsRead);
@@ -36,7 +19,7 @@ public class ReadEventsTests : IAsyncLifetime
     [Fact]
     public async Task ReadsAllEventsFromTheGivenSubject()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -64,7 +47,7 @@ public class ReadEventsTests : IAsyncLifetime
     [Fact]
     public async Task ReadsRecursively()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -92,7 +75,7 @@ public class ReadEventsTests : IAsyncLifetime
     [Fact]
     public async Task ReadsChronologically()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -133,7 +116,7 @@ public class ReadEventsTests : IAsyncLifetime
     [Fact]
     public async Task ReadsAntiChronologically()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -174,7 +157,7 @@ public class ReadEventsTests : IAsyncLifetime
     [Fact]
     public async Task ReadsWithLowerBound()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -211,7 +194,7 @@ public class ReadEventsTests : IAsyncLifetime
     [Fact]
     public async Task ReadsWithUpperBound()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -248,7 +231,7 @@ public class ReadEventsTests : IAsyncLifetime
     [Fact]
     public async Task ReadsFromLatestEvent()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);

--- a/src/EventSourcingDb.Tests/RunEventQlQueryTests.cs
+++ b/src/EventSourcingDb.Tests/RunEventQlQueryTests.cs
@@ -7,29 +7,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class RunEventQlQueryTests : IAsyncLifetime
+public class RunEventQlQueryTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task ReadsNoRowsIfTheQueryDoesNotReturnAnyRows()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var rowsRead = await client.RunEventQlQueryAsync<Event>("FROM e IN events PROJECT INTO e").ToListAsync();
 
@@ -39,7 +22,7 @@ public class RunEventQlQueryTests : IAsyncLifetime
     [Fact]
     public async Task ReadsAllRowsTheQueryReturnsEvents()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -80,7 +63,7 @@ public class RunEventQlQueryTests : IAsyncLifetime
     [Fact]
     public async Task ReadsAllRowsTheQueryReturnsAggregation()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -115,7 +98,7 @@ public class RunEventQlQueryTests : IAsyncLifetime
     [Fact]
     public async Task ThrowsOnDeserializationError()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var eventData = new EventData(23);
         var eventCandidate = new EventCandidate(
@@ -139,7 +122,7 @@ public class RunEventQlQueryTests : IAsyncLifetime
     [Fact]
     public async Task AllowsNullResults()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var eventData = new EventData(23);
         var eventCandidate = new EventCandidate(

--- a/src/EventSourcingDb.Tests/VerifyApiTokenTests.cs
+++ b/src/EventSourcingDb.Tests/VerifyApiTokenTests.cs
@@ -4,29 +4,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class VerifyApiTokenTests : IAsyncLifetime
+public class VerifyApiTokenTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task DoesNotThrowIfTheTokenIsValid()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         // Should not throw.
         await client.VerifyApiTokenAsync();
@@ -35,8 +18,8 @@ public class VerifyApiTokenTests : IAsyncLifetime
     [Fact]
     public async Task ThrowsIfTheTokenIsInvalid()
     {
-        var url = _container!.GetBaseUrl();
-        var invalidApiToken = $"{_container.GetApiToken()}-invalid";
+        var url = Container!.GetBaseUrl();
+        var invalidApiToken = $"{Container.GetApiToken()}-invalid";
 
         var client = new Client(url, invalidApiToken);
 

--- a/src/EventSourcingDb.Tests/VerifyHashTests.cs
+++ b/src/EventSourcingDb.Tests/VerifyHashTests.cs
@@ -9,29 +9,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class VerifyHashTests : IAsyncLifetime
+public class VerifyHashTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task VerifyHash()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var eventCandidate = new EventCandidate(
             Source: "https://www.eventsourcingdb.io",
@@ -49,7 +32,7 @@ public class VerifyHashTests : IAsyncLifetime
     [Fact]
     public async Task ThrowsWhenHashVerificationFails()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var eventCandidate = new EventCandidate(
             Source: "https://www.eventsourcingdb.io",

--- a/src/EventSourcingDb.Tests/WriteEventsTests.cs
+++ b/src/EventSourcingDb.Tests/WriteEventsTests.cs
@@ -8,29 +8,12 @@ using Xunit;
 
 namespace EventSourcingDb.Tests;
 
-public class WriteEventsTests : IAsyncLifetime
+public class WriteEventsTests : EventSourcingDbTests
 {
-    private Container? _container;
-
-    public async Task InitializeAsync()
-    {
-        var imageVersion = DockerfileHelper.GetImageVersionFromDockerfile();
-        _container = new Container().WithImageTag(imageVersion);
-        await _container.StartAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_container is not null)
-        {
-            await _container.StopAsync();
-        }
-    }
-
     [Fact]
     public async Task WritesASingleEvent()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var eventCandidate = new EventCandidate(
             Source: "https://www.eventsourcingdb.io",
@@ -48,7 +31,7 @@ public class WriteEventsTests : IAsyncLifetime
     [Fact]
     public async Task WritesMultipleEvents()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -86,7 +69,7 @@ public class WriteEventsTests : IAsyncLifetime
     [Fact]
     public async Task SupportsTheIsSubjectPristinePrecondition()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -119,7 +102,7 @@ public class WriteEventsTests : IAsyncLifetime
     [Fact]
     public async Task SupportsTheIsSubjectOnEventIdPrecondition()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -152,7 +135,7 @@ public class WriteEventsTests : IAsyncLifetime
     [Fact]
     public async Task SupportsTheIsEventQlQueryTruePrecondition()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var firstData = new EventData(23);
         var secondData = new EventData(42);
@@ -185,7 +168,7 @@ public class WriteEventsTests : IAsyncLifetime
     [Fact]
     public async Task DeserializesEventDataCorrectly()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         var eventCandidate = new EventCandidate(
             Source: "https://www.eventsourcingdb.io",
@@ -205,7 +188,7 @@ public class WriteEventsTests : IAsyncLifetime
     [Fact]
     public async Task PassesErrorMessageInException()
     {
-        var client = _container!.GetClient();
+        var client = Container!.GetClient();
 
         const string invalidSubject = "test"; // Subjects must start with a slash
 


### PR DESCRIPTION
This change makes test code more DRY by using a base class for all tests that need a testcontainer setup.