### PR TITLE
feat: Inject http client into the (ESDB) client

### DIFF
--- a/src/EventSourcingDb.Tests/PingTests.cs
+++ b/src/EventSourcingDb.Tests/PingTests.cs
@@ -24,7 +24,10 @@ public sealed class PingTests : EventSourcingDbTests
         var apiToken = Container.GetApiToken();
 
         var invalidUri = new Uri($"http://non-existent-host:{port}/");
-        var client = new Client(invalidUri, apiToken);
+
+        var httpClient = HttpClientFactory.GetConfiguredDefaultClient(invalidUri, apiToken);
+
+        var client = new Client(httpClient);
 
         await Assert.ThrowsAsync<HttpRequestException>(async () =>
         {

--- a/src/EventSourcingDb.Tests/VerifyApiTokenTests.cs
+++ b/src/EventSourcingDb.Tests/VerifyApiTokenTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -19,9 +20,11 @@ public class VerifyApiTokenTests : EventSourcingDbTests
     public async Task ThrowsIfTheTokenIsInvalid()
     {
         var url = Container!.GetBaseUrl();
-        var invalidApiToken = $"{Container.GetApiToken()}-invalid";
+        var invalidApiToken = $"{Container!.GetApiToken()}-invalid";
 
-        var client = new Client(url, invalidApiToken);
+        var httpClient = HttpClientFactory.GetConfiguredDefaultClient(url, invalidApiToken);
+
+        var client = new Client(httpClient);
 
         await Assert.ThrowsAsync<HttpRequestException>(async () =>
         {

--- a/src/EventSourcingDb/Container.cs
+++ b/src/EventSourcingDb/Container.cs
@@ -94,6 +94,8 @@ public class Container
 
     public IClient GetClient(JsonSerializerOptions? dataSerializerOptions = null)
     {
-        return new Client(GetBaseUrl(), GetApiToken(), dataSerializerOptions);
+        var httpClient = HttpClientFactory.GetConfiguredDefaultClient(GetBaseUrl(), GetApiToken());
+
+        return new Client(httpClient, dataSerializerOptions);
     }
 }

--- a/src/EventSourcingDb/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/EventSourcingDb/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http.Headers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -24,12 +25,16 @@ public static class ServiceCollectionExtensions
             services.PostConfigure(configureOptions);
         }
 
-        services.AddScoped<IClient>(sp =>
+        services.AddHttpClient<IClient, Client>((client, sp) =>
             {
                 var options = sp.GetRequiredService<IOptions<EventSourcingDbOptions>>().Value;
+
+                client.BaseAddress = options.BaseUrl;
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiToken);
+
                 var logger = sp.GetRequiredService<ILogger<Client>>();
 
-                return new Client(options.BaseUrl, options.ApiToken, logger);
+                return new Client(client, logger);
             }
         );
     }

--- a/src/EventSourcingDb/EventSourcingDb.csproj
+++ b/src/EventSourcingDb/EventSourcingDb.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9"/>
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9"/>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EventSourcingDb/HttpClientExtensions.cs
+++ b/src/EventSourcingDb/HttpClientExtensions.cs
@@ -1,0 +1,14 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace EventSourcingDb;
+
+public static class HttpClientExtensions
+{
+    public static HttpClient AuthorizeWithBearerToken(this HttpClient httpClient, string apiToken)
+    {
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
+
+        return httpClient;
+    }
+}

--- a/src/EventSourcingDb/HttpClientFactory.cs
+++ b/src/EventSourcingDb/HttpClientFactory.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Net.Http;
+
+namespace EventSourcingDb;
+
+public class HttpClientFactory
+{
+    public static HttpClient GetConfiguredDefaultClient(Uri baseUrl, string apiToken)
+    {
+        var handler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(2) };
+
+        return new HttpClient(handler) { BaseAddress = baseUrl }.AuthorizeWithBearerToken(apiToken);
+    }
+}


### PR DESCRIPTION
This is a breaking change.

The idea is to separate the concerns of http client management from the logic which uses the http client to make calls to the ESDB server.

The benefits of this approach are:
- Centralization of the configuration of the http client (base url and api token)
- Possibility to hook into request execution pipeline (e.g. to control resilience, custom headers, logging, routing, ...). This would still need to be enabled in the `ServiceCollectionExtensions` in another PR.

Instantiating the client manually requires the slight overhead of creating a `HttpClient` first, but we can offer a static factory for this simple case (see `HttpClientFactory.cs`).

The current solution is technically fine though and respects best practices around pooled connections, see [here](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines).

Just an idea, happy to discuss.
