### PR TITLE
feat: Add optional serializer settings parameter to dependency injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Optionally, you might provide a `CancellationToken`.
 
 Basically, `System.Text.Json` is used for JSON serialization and deserialization.
 
-You can override the default settings by either using JSON attributes on your types and properties or by providing your own `JsonSerializerOptions` when creating the `Client`.
+You can override the default settings by either using JSON attributes on your types and properties or by providing your own `JsonSerializerOptions` when creating the `Client` both manually or via [dependency injection](#dependency-injection).
 
 ## Writing Events
 

--- a/src/EventSourcingDb/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/EventSourcingDb/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -11,7 +12,8 @@ public static class ServiceCollectionExtensions
     public static void AddEventSourcingDb(
         this IServiceCollection services,
         IConfiguration configuration,
-        Action<EventSourcingDbOptions>? configureOptions = null
+        Action<EventSourcingDbOptions>? configureOptions = null,
+        JsonSerializerOptions? jsonSerializerOptions = null
     )
     {
         services
@@ -29,7 +31,7 @@ public static class ServiceCollectionExtensions
                 var options = sp.GetRequiredService<IOptions<EventSourcingDbOptions>>().Value;
                 var logger = sp.GetRequiredService<ILogger<Client>>();
 
-                return new Client(options.BaseUrl, options.ApiToken, logger);
+                return new Client(options.BaseUrl, options.ApiToken, jsonSerializerOptions, logger);
             }
         );
     }


### PR DESCRIPTION
Connecting the dots between custom serializer settings (https://github.com/thenativeweb/eventsourcingdb-client-dotnet/pull/47) and dependency injection (https://github.com/thenativeweb/eventsourcingdb-client-dotnet/pull/68).