### PR TITLE
feat: Implement event schema registration and add tests

### DIFF
--- a/src/EventSourcingDb.Tests/RegisterEventSchemaTests.cs
+++ b/src/EventSourcingDb.Tests/RegisterEventSchemaTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventSourcingDb.Tests;
+
+public class RegisterEventSchemaTests : EventSourcingDbTests
+{
+    [Fact]
+    public async Task RegistersAnEventSchema()
+    {
+        var client = Container!.GetClient();
+
+        const string eventType = "io.eventsourcingdb.test";
+        var schema = new Dictionary<string, object>
+        {
+            ["type"] = "object",
+            ["properties"] = new Dictionary<string, object>
+            {
+                ["value"] = new Dictionary<string, object>
+                {
+                    ["type"] = "number"
+                }
+            },
+            ["required"] = new[] { "value" },
+            ["additionalProperties"] = false
+        };
+
+        var exception = await Record.ExceptionAsync(() => client.RegisterEventSchemaAsync(eventType, schema));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ReturnsErrorIfEventSchemaAlreadyRegistered()
+    {
+        var client = Container!.GetClient();
+
+        const string eventType = "io.eventsourcingdb.test";
+        var schema = new Dictionary<string, object>
+        {
+            ["type"] = "object",
+            ["properties"] = new Dictionary<string, object>
+            {
+                ["value"] = new Dictionary<string, object>
+                {
+                    ["type"] = "number"
+                }
+            },
+            ["required"] = new[] { "value" },
+            ["additionalProperties"] = false
+        };
+
+        await client.RegisterEventSchemaAsync(eventType, schema);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.RegisterEventSchemaAsync(eventType, schema));
+    }
+}

--- a/src/EventSourcingDb/Client.cs
+++ b/src/EventSourcingDb/Client.cs
@@ -416,7 +416,7 @@ public class Client : IClient
         string eventType,
         CancellationToken token = default)
     {
-        var readEventTypeUrl = new Uri(_baseUrl, $"/api/v1/read-event-type");
+        var readEventTypeUrl = new Uri(_baseUrl, "/api/v1/read-event-type");
 
         _logger.LogTrace("Trying to read event type using url '{Url}'...", readEventTypeUrl);
 
@@ -440,6 +440,30 @@ public class Client : IClient
         }
 
         return eventTypeResponse;
+    }
+
+    public async Task RegisterEventSchemaAsync(
+        string eventType,
+        Dictionary<string, object> schema,
+        CancellationToken token = default)
+    {
+        var registerEventSchemaUrl = new Uri(_baseUrl, "/api/v1/register-event-schema");
+
+        var requestBody = new
+        {
+            eventType,
+            schema
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, registerEventSchemaUrl);
+        request.Content = new StringContent(
+            JsonSerializer.Serialize(requestBody, _defaultSerializerOptions),
+            Encoding.UTF8,
+            MediaTypeNames.Application.Json
+        );
+
+        using var response = await _httpClient.SendAsync(request, token).ConfigureAwait(false);
+        await response.ThrowIfNotSuccessStatusCode(token);
     }
 
     public async IAsyncEnumerable<TRow?> RunEventQlQueryAsync<TRow>(

--- a/src/EventSourcingDb/IClient.cs
+++ b/src/EventSourcingDb/IClient.cs
@@ -68,6 +68,16 @@ public interface IClient
     );
 
     /// <summary>
+    /// Registers a new event schema for a given event type.
+    /// If a schema for the event type already exists, an error is returned.
+    /// </summary>
+    Task RegisterEventSchemaAsync(
+        string eventType,
+        Dictionary<string, object> schema,
+        CancellationToken token = default
+    );
+
+    /// <summary>
     /// Runs an EventQL query and returns rows according to the projection from the query.
     /// </summary>
     IAsyncEnumerable<TRow?> RunEventQlQueryAsync<TRow>(


### PR DESCRIPTION
Implements https://github.com/thenativeweb/eventsourcingdb-client-dotnet/issues/57

@goloroden I adopted the tests from the Go SDK. Is that sufficient or do we want to test more scenarios, e.g. what happens when a schema is registered after events of the given type are written?