### PR TITLE
chore: Add 7-day cooldown to Dependabot version updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: nuget
     directory: "/src/EventSourcingDb"
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -17,6 +19,8 @@ updates:
 
   - package-ecosystem: nuget
     directory: "/src/EventSourcingDb.Tests"
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -32,6 +36,8 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/docker"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -44,6 +50,8 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What

Adds a 7-day cooldown (`cooldown.default-days: 7`) to **every** entry in `.github/dependabot.yml`. Dependabot now waits 7 days after a dependency publishes a new version before opening an update PR.

## Why

Freshly released versions are occasionally yanked or ship regressions or supply-chain issues shortly after publication. A 7-day cooldown lets new releases settle before they are proposed, reducing noise and risk while keeping us reasonably current.

The `cooldown` option is supported by all package ecosystems configured in this repository.
